### PR TITLE
Fix BL, Added button to copy all incoming references, added chicken bone names from Rising

### DIFF
--- a/src/gui/strings.rs
+++ b/src/gui/strings.rs
@@ -270,6 +270,7 @@ fn truncate_string_stripped(s: &str, max_length: usize) -> String {
 
 fn dump_all_languages() -> anyhow::Result<()> {
     let prebl = package_manager().version == GameVersion::Destiny2Shadowkeep;
+    let bl = package_manager().version == GameVersion::Destiny2BeyondLight;
 
     std::fs::create_dir("strings").ok();
     let mut files: FxHashMap<String, File> = Default::default();
@@ -292,7 +293,7 @@ fn dump_all_languages() -> anyhow::Result<()> {
                 continue;
             };
             let mut cur = Cursor::new(&data);
-            let text_data: StringData = cur.read_le_args((prebl,))?;
+            let text_data: StringData = cur.read_le_args((prebl,bl))?;
 
             for (combination, hash) in text_data
                 .string_combinations

--- a/src/gui/tag.rs
+++ b/src/gui/tag.rs
@@ -834,6 +834,22 @@ impl View for TagView {
             {
                 open_tag_in_default_application(self.tag_entry.reference.into());
             }
+
+            
+            if ui.button("Copy all hashes referencing this tag").clicked() {
+                let mut tag_hashes = Vec::new();
+                for (tag, entry) in &self.scan.references {
+                    tag_hashes.push(*tag);
+                }
+
+                let tag_hashes_str = tag_hashes
+                    .iter()
+                    .map(|hash| format!("{}", hash))
+                    .collect::<Vec<String>>()
+                    .join("\n");
+
+                ui.output_mut(|o| o.copied_text = tag_hashes_str);
+            }
         });
 
         ui.separator();

--- a/src/gui/tag.rs
+++ b/src/gui/tag.rs
@@ -837,14 +837,9 @@ impl View for TagView {
 
             
             if ui.button("Copy all hashes referencing this tag").clicked() {
-                let mut tag_hashes = Vec::new();
-                for (tag, entry) in &self.scan.references {
-                    tag_hashes.push(*tag);
-                }
-
-                let tag_hashes_str = tag_hashes
+                let tag_hashes_str = self.scan.references
                     .iter()
-                    .map(|hash| format!("{}", hash))
+                    .map(|(hash, _entry)| format!("{}", hash))
                     .collect::<Vec<String>>()
                     .join("\n");
 


### PR DESCRIPTION
- Beyond Light would crash when trying to build cache due to string_combinations, so thats fixed now
- Added a button along side "Open tag.." and "Open reference.." buttons that copies all hashes of incoming references
- Added Chicken bone names from Rising to the wordlist