### PR TITLE
feat: Support PS4 D2 textures

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1033,9 +1033,9 @@ dependencies = [
 
 [[package]]
 name = "destiny-pkg"
-version = "0.12.2"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78d4f945fbd5fd6ad4afbd963dec2bede05d078bd909c3b4a2e1dcf93e5ba7c8"
+checksum = "22edba1c037da388ac6ba361eb3184c1e126d1dc3130714fb7f511a9c4b44e08"
 dependencies = [
  "aes",
  "aes-gcm",
@@ -2847,7 +2847,7 @@ dependencies = [
  "chrono",
  "clap",
  "clipboard-win",
- "destiny-pkg 0.12.2",
+ "destiny-pkg 0.13.0",
  "eframe",
  "egui-notify",
  "egui_extras",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,7 +39,7 @@ rayon = "1.8.0"
 base64 = "0.22.0"
 bincode = "2.0.0-rc.3"
 binrw = "0.13.3"
-destiny-pkg = { version = "0.12.2", features = ["bincode"] }
+destiny-pkg = { version = "0.13.0", features = ["bincode"] }
 serde = { version = "1.0.188", features = ["derive"] }
 serde_json = "1.0.108"
 vgmstream = { git = "https://github.com/cohaereo/vgmstream-rs/", version = "0.1.5", optional = true }

--- a/src/gui/strings.rs
+++ b/src/gui/strings.rs
@@ -82,7 +82,9 @@ impl View for StringsView {
             .resizable(true)
             .min_width(384.0)
             .show_inside(ui, |ui| {
-                if self.variant == StringViewVariant::LocalizedStrings && ui.button("Dump all languages").clicked() {
+                if self.variant == StringViewVariant::LocalizedStrings
+                    && ui.button("Dump all languages").clicked()
+                {
                     dump_all_languages().unwrap();
                 }
 
@@ -267,7 +269,10 @@ fn truncate_string_stripped(s: &str, max_length: usize) -> String {
 }
 
 fn dump_all_languages() -> anyhow::Result<()> {
-    let prebl = package_manager().version == GameVersion::Destiny2Shadowkeep;
+    let prebl = matches!(
+        package_manager().version,
+        GameVersion::Destiny2Beta | GameVersion::Destiny2Forsaken | GameVersion::Destiny2Shadowkeep
+    );
     let bl = package_manager().version == GameVersion::Destiny2BeyondLight;
 
     std::fs::create_dir("strings").ok();
@@ -291,7 +296,7 @@ fn dump_all_languages() -> anyhow::Result<()> {
                 continue;
             };
             let mut cur = Cursor::new(&data);
-            let text_data: StringData = cur.read_le_args((prebl,bl))?;
+            let text_data: StringData = cur.read_le_args((prebl, bl))?;
 
             for (combination, hash) in text_data
                 .string_combinations

--- a/src/gui/texture.rs
+++ b/src/gui/texture.rs
@@ -1,8 +1,7 @@
-use crate::gui::dxgi::DxgiFormat;
 use crate::gui::texture::texture_capture::capture_texture;
 use crate::package_manager::package_manager;
 use anyhow::Context;
-use binrw::{BinRead, BinReaderExt};
+use binrw::BinReaderExt;
 use destiny_pkg::package::PackagePlatform;
 use destiny_pkg::{GameVersion, TagHash};
 use eframe::egui::load::SizedTexture;
@@ -13,114 +12,42 @@ use eframe::wgpu;
 use eframe::wgpu::util::DeviceExt;
 use eframe::wgpu::TextureDimension;
 use either::Either::{self, Left};
+use headers_pc::TextureHeaderPC;
+use headers_ps::{TextureHeaderD2Ps4, TextureHeaderRoiPs4};
+use headers_xbox::{TextureHeaderDevAlphaX360, TextureHeaderRoiXbox};
 use image::{DynamicImage, GenericImageView};
 
 use linked_hash_map::LinkedHashMap;
 use poll_promise::Promise;
 use rustc_hash::FxHasher;
 use std::hash::BuildHasherDefault;
-use std::io::SeekFrom;
 use swizzle_ps4::GcnDeswizzler;
 use swizzle_x360::XenosDetiler;
 
 use std::rc::Rc;
 use std::sync::Arc;
 
-use super::dxgi::{GcnSurfaceFormat, XenosSurfaceFormat};
+use super::dxgi::GcnSurfaceFormat;
 
 mod swizzle_ps4;
 mod swizzle_x360;
 
-#[derive(Debug, BinRead)]
-#[br(import(prebl: bool))]
-pub struct TextureHeader {
+mod headers_pc;
+mod headers_ps;
+mod headers_xbox;
+
+#[derive(Debug)]
+pub struct TextureHeaderGeneric {
     pub data_size: u32,
-    pub format: DxgiFormat,
-    pub _unk8: u32,
-
-    #[br(if(!prebl))]
-    pub _unkc: [u32; 5],
-
-    #[br(assert(cafe == 0xcafe))]
-    pub cafe: u16, // prebl: 0xc / bl: 0x20
-
-    pub width: u16,      // prebl: 0xe / bl: 0x22
-    pub height: u16,     // prebl: 0x10 / bl: 0x24
-    pub depth: u16,      // prebl: 0x12 / bl: 0x26
-    pub array_size: u16, // prebl: 0x14 / bl: 0x28
-
-    pub _pad0: [u16; 7], // prebl: 0x16 / bl: 0x2a
-
-    #[br(if(!prebl))]
-    pub _pad1: u32,
-
-    // pub _unk2a: [u32; 4]
-    // pub unk2a: u16,
-    // pub unk2c: u8,
-    // pub mip_count: u8,
-    // pub unk2e: [u8; 10],
-    // pub unk38: u32,
-    #[br(map(|v: u32| (v != u32::MAX).then_some(TagHash(v))))]
-    pub large_buffer: Option<TagHash>, // prebl: 0x24 / bl: 0x3c
-}
-
-#[derive(Debug, BinRead)]
-pub struct TextureHeaderRoiPs4 {
-    pub data_size: u32,
-    pub unk4: u8,
-    pub unk5: u8,
-    #[br(try_map(|v: u16| GcnSurfaceFormat::try_from((v >> 4) & 0x3F)))]
-    pub format: GcnSurfaceFormat,
-
-    #[br(seek_before = SeekFrom::Start(0x24), assert(beefcafe == 0xbeefcafe))]
-    pub beefcafe: u32,
-
+    pub format: wgpu::TextureFormat,
     pub width: u16,
     pub height: u16,
     pub depth: u16,
     pub array_size: u16,
+    pub large_buffer: Option<TagHash>,
 
-    pub flags1: u32,
-    pub flags2: u32,
-    pub flags3: u32,
-}
-
-#[derive(Debug, BinRead)]
-pub struct TextureHeaderDevAlphaX360 {
-    #[br(seek_before = SeekFrom::Start(0x20))]
-    _dataformat: u32,
-
-    #[br(calc((_dataformat & 0x80) != 0))]
-    pub unk_flag: bool,
-
-    #[br(try_calc(XenosSurfaceFormat::try_from(_dataformat as u8 & 0x3F)))]
-    pub format: XenosSurfaceFormat,
-
-    #[br(seek_before = SeekFrom::Start(0x36))]
-    pub width: u16,
-    pub height: u16,
-    pub depth: u16,
-    // pub flags1: u32,
-    // pub flags2: u32,
-    // pub flags3: u32,
-    #[br(seek_before = SeekFrom::Start(0x48), assert(beefcafe == 0xbeefcafe))]
-    pub beefcafe: u32,
-}
-
-#[derive(Debug, BinRead)]
-pub struct TextureHeaderRoiXbox {
-    pub format: DxgiFormat,
-
-    #[br(seek_before = SeekFrom::Start(0x2c), assert(beefcafe == 0xbeefcafe))]
-    pub beefcafe: u32,
-
-    pub width: u16,
-    pub height: u16,
-    pub depth: u16,
-    pub array_size: u16,
-    // pub flags1: u32,
-    // pub flags2: u32,
-    // pub flags3: u32,
+    pub deswizzle: Option<bool>,
+    pub psformat: Option<GcnSurfaceFormat>,
 }
 
 pub struct Texture {
@@ -158,7 +85,7 @@ impl Texture {
     pub fn load_data_d2(
         hash: TagHash,
         load_full_mip: bool,
-    ) -> anyhow::Result<(TextureHeader, Vec<u8>, String)> {
+    ) -> anyhow::Result<(TextureHeaderGeneric, Vec<u8>, String)> {
         let texture_header_ref = package_manager()
             .get_entry(hash)
             .context("Texture header entry not found")?
@@ -171,11 +98,45 @@ impl Texture {
         // TODO(cohae): add a method to GameVersion to check for prebl
         let is_prebl = matches!(
             package_manager().version,
-            destiny_pkg::GameVersion::Destiny2Beta | destiny_pkg::GameVersion::Destiny2Shadowkeep
+            GameVersion::Destiny2Beta
+                | GameVersion::Destiny2Forsaken
+                | GameVersion::Destiny2Shadowkeep
         );
 
         let mut cur = std::io::Cursor::new(header_data);
-        let texture: TextureHeader = cur.read_le_args((is_prebl,))?;
+        let texture: TextureHeaderGeneric = match package_manager().platform {
+            PackagePlatform::PS4 => {
+                let texheader: TextureHeaderD2Ps4 = cur.read_le_args((is_prebl,))?;
+                TextureHeaderGeneric {
+                    data_size: texheader.data_size,
+                    format: texheader.format.to_wgpu()?,
+                    width: texheader.width,
+                    height: texheader.height,
+                    depth: texheader.depth,
+                    array_size: texheader.array_size,
+                    large_buffer: texheader.large_buffer,
+
+                    deswizzle: Some((texheader.flags1 & 0xc00) != 0x400),
+                    psformat: Some(texheader.format),
+                }
+            }
+            PackagePlatform::Win64 => {
+                let texheader: TextureHeaderPC = cur.read_le_args((is_prebl,))?;
+                TextureHeaderGeneric {
+                    data_size: texheader.data_size,
+                    format: texheader.format.to_wgpu()?,
+                    width: texheader.width,
+                    height: texheader.height,
+                    depth: texheader.depth,
+                    array_size: texheader.array_size,
+                    large_buffer: texheader.large_buffer,
+
+                    deswizzle: None,
+                    psformat: None,
+                }
+            }
+            _ => unreachable!("Unsupported platform for D2 textures"),
+        };
         let mut texture_data = if let Some(t) = texture.large_buffer {
             package_manager()
                 .read_tag(t)
@@ -197,7 +158,45 @@ impl Texture {
         }
 
         let comment = format!("{texture:#X?}");
-        Ok((texture, texture_data, comment))
+
+        match package_manager().platform {
+            PackagePlatform::PS4 => {
+                if texture.deswizzle.is_none() || texture.psformat.is_none() {
+                    anyhow::bail!(
+                        "Texture data not found: deswizzle: {:?}, psformat: {:?}",
+                        texture.deswizzle,
+                        texture.psformat
+                    );
+                }
+                let psformat = texture.psformat.unwrap();
+                let expected_size =
+                    (texture.width as usize * texture.height as usize * psformat.bpp()) / 8;
+
+                if texture_data.len() < expected_size {
+                    anyhow::bail!(
+                        "Texture data size mismatch for {hash} ({}x{}x{} {:?}): expected {expected_size}, got {}",
+                        texture.width, texture.height, texture.depth, texture.format,
+                        texture_data.len()
+                    );
+                }
+
+                if texture.deswizzle.unwrap() {
+                    let unswizzled = GcnDeswizzler::deswizzle(
+                        &texture_data,
+                        texture.width as usize,
+                        texture.height as usize,
+                        texture.depth as usize,
+                        texture.psformat.unwrap(),
+                        false,
+                    )
+                    .context("Failed to deswizzle texture")?;
+                    Ok((texture, unswizzled, comment))
+                } else {
+                    Ok((texture, texture_data, comment))
+                }
+            }
+            _ => Ok((texture, texture_data, comment)),
+        }
     }
 
     pub fn load_data_roi_ps4(
@@ -246,6 +245,7 @@ impl Texture {
                 texture.height as usize,
                 texture.depth as usize,
                 texture.format,
+                true,
             )
             .context("Failed to deswizzle texture")?;
 
@@ -255,7 +255,7 @@ impl Texture {
         }
     }
 
-    pub fn load_data_roi_x360(
+    pub fn load_data_devalpha_x360(
         hash: TagHash,
         _load_full_mip: bool,
     ) -> anyhow::Result<(TextureHeaderDevAlphaX360, Vec<u8>, String)> {
@@ -301,6 +301,7 @@ impl Texture {
             texture.height as usize,
             texture.depth as usize,
             texture.format,
+            false,
         )
         .context("Failed to deswizzle texture")?;
 
@@ -427,28 +428,55 @@ impl Texture {
             | GameVersion::Destiny2BeyondLight
             | GameVersion::Destiny2WitchQueen
             | GameVersion::Destiny2Lightfall
-            | GameVersion::Destiny2TheFinalShape => {
-                let header_data = package_manager()
-                    .read_tag(hash)
-                    .context("Failed to read texture header")?;
+            | GameVersion::Destiny2TheFinalShape => match package_manager().platform {
+                PackagePlatform::PS4 => {
+                    let header_data = package_manager()
+                        .read_tag(hash)
+                        .context("Failed to read texture header")?;
 
-                let is_prebl = matches!(
-                    package_manager().version,
-                    destiny_pkg::GameVersion::Destiny2Beta
-                        | destiny_pkg::GameVersion::Destiny2Shadowkeep
-                );
+                    let is_prebl = matches!(
+                        package_manager().version,
+                        GameVersion::Destiny2Beta
+                            | GameVersion::Destiny2Forsaken
+                            | GameVersion::Destiny2Shadowkeep
+                    );
 
-                let mut cur = std::io::Cursor::new(header_data);
-                let texture: TextureHeader = cur.read_le_args((is_prebl,))?;
+                    let mut cur = std::io::Cursor::new(header_data);
+                    let texture: TextureHeaderD2Ps4 = cur.read_le_args((is_prebl,))?;
 
-                Ok(TextureDesc {
-                    format: texture.format.to_wgpu()?,
-                    width: texture.width as u32,
-                    height: texture.height as u32,
-                    depth: texture.depth as u32,
-                    premultiply_alpha: false,
-                })
-            }
+                    Ok(TextureDesc {
+                        format: texture.format.to_wgpu()?,
+                        width: texture.width as u32,
+                        height: texture.height as u32,
+                        depth: texture.depth as u32,
+                        premultiply_alpha: false,
+                    })
+                }
+                PackagePlatform::Win64 => {
+                    let header_data = package_manager()
+                        .read_tag(hash)
+                        .context("Failed to read texture header")?;
+
+                    let is_prebl = matches!(
+                        package_manager().version,
+                        GameVersion::Destiny2Beta
+                            | GameVersion::Destiny2Forsaken
+                            | GameVersion::Destiny2Shadowkeep
+                    );
+
+                    let mut cur = std::io::Cursor::new(header_data);
+                    let texture: TextureHeaderPC = cur.read_le_args((is_prebl,))?;
+
+                    Ok(TextureDesc {
+                        format: texture.format.to_wgpu()?,
+                        width: texture.width as u32,
+                        height: texture.height as u32,
+                        depth: texture.depth as u32,
+                        premultiply_alpha: false,
+                    })
+                }
+                _ => unreachable!("Unsupported platform for D2 textures"),
+            },
         }
     }
 
@@ -474,7 +502,7 @@ impl Texture {
                 match package_manager().platform {
                     PackagePlatform::X360 => {
                         let (texture, texture_data, comment) =
-                            Self::load_data_roi_x360(hash, true)?;
+                            Self::load_data_devalpha_x360(hash, true)?;
                         Self::create_texture(
                             rs,
                             hash,
@@ -540,7 +568,7 @@ impl Texture {
                     rs,
                     hash,
                     TextureDesc {
-                        format: texture.format.to_wgpu()?,
+                        format: texture.format,
                         width: texture.width as u32,
                         height: texture.height as u32,
                         depth: texture.depth as u32,
@@ -841,6 +869,9 @@ trait Deswizzler {
         height: usize,
         depth: usize,
         format: Self::Format,
+        // PS4 D2 causes issues if compressed textures are aligned on power of two
+        // however on D1 it'll cause issues if *not* aligned
+        align_output: bool,
     ) -> anyhow::Result<Vec<u8>>;
 }
 

--- a/src/gui/texture.rs
+++ b/src/gui/texture.rs
@@ -462,7 +462,7 @@ impl Texture {
                         height: texture.height as u32,
                         depth: texture.depth as u32,
                         array_size: texture.array_size as u32,
-                    premultiply_alpha: false,
+                        premultiply_alpha: false,
                     })
                 }
                 PackagePlatform::Win64 => {
@@ -485,6 +485,7 @@ impl Texture {
                         width: texture.width as u32,
                         height: texture.height as u32,
                         depth: texture.depth as u32,
+                        array_size: texture.array_size as u32,
                         premultiply_alpha: false,
                     })
                 }

--- a/src/gui/texture/headers_pc.rs
+++ b/src/gui/texture/headers_pc.rs
@@ -1,0 +1,37 @@
+use binrw::BinRead;
+use destiny_pkg::TagHash;
+
+use crate::gui::dxgi::DxgiFormat;
+
+#[derive(Debug, BinRead)]
+#[br(import(prebl: bool))]
+pub struct TextureHeaderPC {
+    pub data_size: u32,
+    pub format: DxgiFormat,
+    pub _unk8: u32,
+
+    #[br(if(!prebl))]
+    pub _unkc: [u32; 5],
+
+    #[br(assert(cafe == 0xcafe))]
+    pub cafe: u16, // prebl: 0xc / bl: 0x20
+
+    pub width: u16,      // prebl: 0xe / bl: 0x22
+    pub height: u16,     // prebl: 0x10 / bl: 0x24
+    pub depth: u16,      // prebl: 0x12 / bl: 0x26
+    pub array_size: u16, // prebl: 0x14 / bl: 0x28
+
+    pub _pad0: [u16; 7], // prebl: 0x16 / bl: 0x2a
+
+    #[br(if(!prebl))]
+    pub _pad1: u32,
+
+    // pub _unk2a: [u32; 4]
+    // pub unk2a: u16,
+    // pub unk2c: u8,
+    // pub mip_count: u8,
+    // pub unk2e: [u8; 10],
+    // pub unk38: u32,
+    #[br(map(|v: u32| (v != u32::MAX).then_some(TagHash(v))))]
+    pub large_buffer: Option<TagHash>, // prebl: 0x24 / bl: 0x3c
+}

--- a/src/gui/texture/headers_ps.rs
+++ b/src/gui/texture/headers_ps.rs
@@ -1,0 +1,58 @@
+use std::io::SeekFrom;
+
+use binrw::BinRead;
+use destiny_pkg::TagHash;
+
+use crate::gui::dxgi::GcnSurfaceFormat;
+
+#[derive(Debug, BinRead)]
+#[br(import(prebl: bool))]
+pub struct TextureHeaderD2Ps4 {
+    pub data_size: u32,
+    pub unk4: u8,
+    pub unk5: u8,
+    #[br(try_map(|v: u16| GcnSurfaceFormat::try_from((v >> 4) & 0x3F)))]
+    pub format: GcnSurfaceFormat,
+
+    #[br(if(prebl))]
+    pub _unkc: [u32; 8],
+
+    #[br(assert(cafe == 0xcafe))]
+    pub cafe: u16,
+
+    pub width: u16,
+    pub height: u16,
+    pub depth: u16,
+    pub array_size: u16,
+
+    pub flags1: u32,
+    pub flags2: u32,
+    pub flags3: u32,
+
+    #[br(if(prebl))]
+    pub _pad1: u16,
+
+    #[br(map(|v: u32| (v != u32::MAX).then_some(TagHash(v))))]
+    pub large_buffer: Option<TagHash>, // prebl: 0x24 / bl: 0x3c
+}
+
+#[derive(Debug, BinRead)]
+pub struct TextureHeaderRoiPs4 {
+    pub data_size: u32,
+    pub unk4: u8,
+    pub unk5: u8,
+    #[br(try_map(|v: u16| GcnSurfaceFormat::try_from((v >> 4) & 0x3F)))]
+    pub format: GcnSurfaceFormat,
+
+    #[br(seek_before = SeekFrom::Start(0x24), assert(beefcafe == 0xbeefcafe))]
+    pub beefcafe: u32,
+
+    pub width: u16,
+    pub height: u16,
+    pub depth: u16,
+    pub array_size: u16,
+
+    pub flags1: u32,
+    pub flags2: u32,
+    pub flags3: u32,
+}

--- a/src/gui/texture/headers_xbox.rs
+++ b/src/gui/texture/headers_xbox.rs
@@ -1,0 +1,43 @@
+use std::io::SeekFrom;
+
+use binrw::BinRead;
+
+use crate::gui::dxgi::{DxgiFormat, XenosSurfaceFormat};
+
+#[derive(Debug, BinRead)]
+pub struct TextureHeaderDevAlphaX360 {
+    #[br(seek_before = SeekFrom::Start(0x20))]
+    _dataformat: u32,
+
+    #[br(calc((_dataformat & 0x80) != 0))]
+    pub unk_flag: bool,
+
+    #[br(try_calc(XenosSurfaceFormat::try_from(_dataformat as u8 & 0x3F)))]
+    pub format: XenosSurfaceFormat,
+
+    #[br(seek_before = SeekFrom::Start(0x36))]
+    pub width: u16,
+    pub height: u16,
+    pub depth: u16,
+    // pub flags1: u32,
+    // pub flags2: u32,
+    // pub flags3: u32,
+    #[br(seek_before = SeekFrom::Start(0x48), assert(beefcafe == 0xbeefcafe))]
+    pub beefcafe: u32,
+}
+
+#[derive(Debug, BinRead)]
+pub struct TextureHeaderRoiXbox {
+    pub format: DxgiFormat,
+
+    #[br(seek_before = SeekFrom::Start(0x2c), assert(beefcafe == 0xbeefcafe))]
+    pub beefcafe: u32,
+
+    pub width: u16,
+    pub height: u16,
+    pub depth: u16,
+    pub array_size: u16,
+    // pub flags1: u32,
+    // pub flags2: u32,
+    // pub flags3: u32,
+}

--- a/src/gui/texture/swizzle_ps4.rs
+++ b/src/gui/texture/swizzle_ps4.rs
@@ -38,16 +38,17 @@ fn do_swizzle(
     height: usize,
     format: GcnSurfaceFormat,
     unswizzle: bool,
+    align_output: bool,
 ) {
     let pixel_block_size = format.pixel_block_size();
     let block_size = format.block_size();
 
-    let width_src = if format.is_compressed() {
+    let width_src = if align_output && format.is_compressed() {
         width.next_power_of_two()
     } else {
         width
     };
-    let height_src = if format.is_compressed() {
+    let height_src = if align_output && format.is_compressed() {
         height.next_power_of_two()
     } else {
         height
@@ -102,9 +103,18 @@ impl Deswizzler for GcnDeswizzler {
         height: usize,
         _depth: usize,
         format: Self::Format,
+        align_output: bool,
     ) -> anyhow::Result<Vec<u8>> {
         let mut converted_data = vec![0; data.len()];
-        do_swizzle(data, &mut converted_data, width, height, format, true);
+        do_swizzle(
+            data,
+            &mut converted_data,
+            width,
+            height,
+            format,
+            true,
+            align_output,
+        );
         Ok(converted_data)
     }
 }

--- a/src/gui/texture/swizzle_ps4.rs
+++ b/src/gui/texture/swizzle_ps4.rs
@@ -43,15 +43,10 @@ fn do_swizzle(
     let pixel_block_size = format.pixel_block_size();
     let block_size = format.block_size();
 
-    let width_src = if align_output && format.is_compressed() {
-        width.next_power_of_two()
+    let (width_src, height_src) = if align_output && format.is_compressed() {
+        (width.next_power_of_two(), height.next_power_of_two())
     } else {
-        width
-    };
-    let height_src = if align_output && format.is_compressed() {
-        height.next_power_of_two()
-    } else {
-        height
+        (width, height)
     };
 
     let width_texels_dest = width / pixel_block_size;

--- a/src/gui/texture/swizzle_x360.rs
+++ b/src/gui/texture/swizzle_x360.rs
@@ -121,6 +121,7 @@ impl Deswizzler for XenosDetiler {
         height: usize,
         _depth: usize,
         format: Self::Format,
+        align_output: bool,
     ) -> anyhow::Result<Vec<u8>> {
         let block_pixel_size;
         let texel_byte_pitch;

--- a/src/text.rs
+++ b/src/text.rs
@@ -387,6 +387,8 @@ pub fn create_stringmap_d2() -> anyhow::Result<StringCache> {
         package_manager().version,
         GameVersion::DestinyTheTakenKing
             | GameVersion::DestinyRiseOfIron
+            | GameVersion::Destiny2Beta
+            | GameVersion::Destiny2Forsaken
             | GameVersion::Destiny2Shadowkeep
     );
     // Beyond Light still uses the same struct layout as prebl, was updated in WQ
@@ -411,7 +413,7 @@ pub fn create_stringmap_d2() -> anyhow::Result<StringCache> {
             continue;
         };
         let mut cur = Cursor::new(&data);
-        let text_data: StringData = cur.read_le_args((prebl,bl))?;
+        let text_data: StringData = cur.read_le_args((prebl, bl))?;
 
         for (combination, hash) in text_data
             .string_combinations


### PR DESCRIPTION
Enables loading textures for PS4 Destiny 2 versions.
Adds Beta and Forsaken to the list of prebl versions in some places where it's used.
Bumps destiny-pkg to 0.13.0